### PR TITLE
Markdown fix

### DIFF
--- a/src/helper/markdown_translator.py
+++ b/src/helper/markdown_translator.py
@@ -49,6 +49,7 @@ def create_individual_analysis_files(results: Dict[Any, Any], base_output_dir: s
     legal_question = results.get('legal_question')
     hypothetical = results.get('hypothetical')
     
+    # just adding this check to be safe but technically its passed on
     if agent_config is None:
         agent_config = load_agents_config()
 
@@ -102,11 +103,12 @@ def _create_internal_markdown(results: Dict, output_file: str, model_name: str, 
     # Internal analysis sections
     internal_data = results['agent_outputs']['internal']
     
+    # just adding this check to be safe but technically its passed on
     if agent_config is None:
         agent_config = load_agents_config()
     internal_phases = list(agent_config["internal"]["phase_prompts"].keys())
 
-    for section in internal_pases:
+    for section in internal_phases:
         if internal_data.get(section):
             section_title = section.replace("_", " ").title()
             markdown.append(f"## {section_title}\n")
@@ -151,6 +153,7 @@ def _create_external_markdown(results: Dict, output_file: str, model_name: str, 
     # External analysis sections
     external_data = results['agent_outputs']['external']
     
+    # just adding this check to be safe but technically its passed on
     if agent_config is None:
         agent_config = load_agents_config()
     external_phases = list(agent_config["external"]["phase_prompts"].keys())

--- a/src/helper/markdown_translator.py
+++ b/src/helper/markdown_translator.py
@@ -4,7 +4,7 @@ from typing import Dict, Any, Optional
 
 _agents_config_cache = None # global cache for agent config
 
-def load_agents_config(agents_json_path: str = "agents.json") -> dict:
+def load_agents_config(agents_json_path: str = "../settings/agents.json") -> dict:
     """
     load the phase configuration from agent.json then write to cache
     """
@@ -18,7 +18,7 @@ def load_agents_config(agents_json_path: str = "agents.json") -> dict:
                 try:
                     _agents_config_cache = json.load(f)
                 except Exception as e:
-                    print(f"Warning: Failed to load agents.json: {e}, using default phases.")
+                    print(f"Warning: Failed to load {agents_json_path}: {e}, using default phases.")
                     _agents_config_cache = {}
     return _agents_config_cache
 
@@ -295,7 +295,7 @@ def _create_review_markdown(results: Dict, output_file: str, model_name: str, ti
         f.write("\n".join(markdown))
 
 
-def convert_to_individual_files(input_file: str, base_output_dir: str, model_name: str = None, hypo_name: str = None, agents_config_json_path: str = "agents.json"):
+def convert_to_individual_files(input_file: str, base_output_dir: str, model_name: str = None, hypo_name: str = None, agents_config_json_path: str = "../settings/agents.json"):
     """
     Convert a legal analysis JSON file to separate internal, external, and review markdown files.
     
@@ -325,7 +325,7 @@ def convert_to_individual_files(input_file: str, base_output_dir: str, model_nam
 
 
 # Legacy function to maintain backward compatibility
-def convert_to_md(input_file, output_file=None, agents_config_json_path: str = "agents.json"):
+def convert_to_md(input_file, output_file=None, agents_config_json_path: str = "../settings/agents.json"):
     """
     Legacy function - converts to single markdown file for backward compatibility
     """

--- a/src/helper/markdown_translator.py
+++ b/src/helper/markdown_translator.py
@@ -22,7 +22,7 @@ def load_agents_config(agents_json_path: str = "agents.json") -> dict:
                     _agents_config_cache = {}
     return _agents_config_cache
 
-def create_individual_analysis_files(results: Dict[Any, Any], base_output_dir: str, model_name: str, hypo_name: str = None) -> None:
+def create_individual_analysis_files(results: Dict[Any, Any], base_output_dir: str, model_name: str, hypo_name: str = None, agent_config:dict) -> None:
     """
     Create separate markdown files for internal, external, and final review analysis.
     
@@ -49,15 +49,18 @@ def create_individual_analysis_files(results: Dict[Any, Any], base_output_dir: s
     legal_question = results.get('legal_question')
     hypothetical = results.get('hypothetical')
     
+    if agent_config is None:
+        agent_config = load_agents_config()
+
     # Generate internal analysis file
     if results.get('agent_outputs', {}).get('internal'):
         internal_file = os.path.join(model_dir, 'internal.md')
-        _create_internal_markdown(results, internal_file, model_name, timestamp, legal_question, hypothetical)
+        _create_internal_markdown(results, internal_file, model_name, timestamp, legal_question, hypothetical, agent_config)
     
     # Generate external analysis file
     if results.get('agent_outputs', {}).get('external'):
         external_file = os.path.join(model_dir, 'external.md')
-        _create_external_markdown(results, external_file, model_name, timestamp, legal_question, hypothetical)
+        _create_external_markdown(results, external_file, model_name, timestamp, legal_question, hypothetical, agent_config)
     
     # Generate review file with synthesis and metrics
     if results.get('final_synthesis'):


### PR DESCRIPTION
* Modified `markdown_translator.py` to load agent config from agents.json and then read phases for internal and external, all relevant functions were edited
* Noting that `legalworkflow.py` (specifically save_individual_hypothetical_results) was **not edited** even though it calls create_individual_analysis_files
* Since agent_config loading is delegated to `markdown_translator.py` and config loading is delegated to _create_<internal/external>_markdown